### PR TITLE
Add subject lesson position details

### DIFF
--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -32,20 +32,20 @@ Assignments contain information about a user's progress on a particular subject,
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
+`available_at` | `null` or Date | Timestamp when the related subject will be available in the user's review queue.
+`burned_at` | `null` or Date | Timestamp when the user reaches SRS stage `9` the first time.
 `created_at` | Date | Timestamp when the assignment was created.
+`hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
+`passed_at` | `null` or Date | Timestamp when the user reaches SRS stage `5` for the first time.
+`passed` | Boolean | The boolean equivalent of `passed_at`
+`resurrected_at` | `null` or Date | Timestamp when the subject is resurrected and placed back in the user's review queue.
+`resurrected` | Boolean | A convenience field indicating that the subject has been burned, resurrected, and is still in the user's review queue.
+`srs_stage_name` | String | The [stage name](#srs-stage-intervals) associated with the `srs_stage`.
+`srs_stage` | Integer | The current [SRS stage interval](#srs-stage-intervals), from `0` to `9`.
+`started_at` | `null` or Date | Timestamp when the user completes the lesson for the related subject.
 `subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
 `subject_type` | String | The type of the associated [subject](#subjects), one of: `kanji`, `radical`, or `vocabulary`.
-`srs_stage` | Integer | The current [SRS stage interval](#srs-stage-intervals), from `0` to `9`.
-`srs_stage_name` | String | The [stage name](#srs-stage-intervals) associated with the `srs_stage`.
 `unlocked_at` | `null` or Date | <p>The timestamp when the related subject has its prerequisites satisfied and is made available in lessons.</p> <p>Prerequisites are:</p><ul><li>The subject components have reached SRS stage `5` once (they have been “passed”).</li><li>The user's level is equal to or greater than the level of the assignment’s subject.</li></ul>
-`started_at` | `null` or Date | Timestamp when the user completes the lesson for the related subject.
-`passed_at` | `null` or Date | Timestamp when the user reaches SRS stage `5` for the first time.
-`burned_at` | `null` or Date | Timestamp when the user reaches SRS stage `9` the first time.
-`available_at` | `null` or Date | Timestamp when the related subject will be available in the user's review queue.
-`resurrected_at` | `null` or Date | Timestamp when the subject is resurrected and placed back in the user's review queue.
-`passed` | Boolean | The boolean equivalent of `passed_at`
-`resurrected` | Boolean | A convenience field indicating that the subject has been burned, resurrected, and is still in the user's review queue.
-`hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
 
 ## Get All Assignments
 
@@ -108,21 +108,21 @@ Name | Data Type | Description
 ---- | ---------------- | -----------
 `available_after` | Date | Only assignments available at or after this time are returned.
 `available_before` | Date | Only assignments available at or before this time are returned.
+`burned` | Boolean | When set to `true`, returns assignments that have a value in `data.burned_at`. Returns assignments with a `null` `data.burned_at` if `false`.
+`hidden` | Boolean | Return assignments with a matching value in the `hidden` attribute
 `ids` | Array of integers | Only assignments where `data.id` matches one of the array values are returned.
+`immediately_available_for_lessons` | (not required) | Returns assignments which are immediately available for lessons
+`immediately_available_for_review` | (not required) | Returns assignments which are immediately available for review
+`in_review` | (not required) | Returns assignments which are in the review state
 `levels` | Array of integers | Only assignments where the associated subject level matches one of the array values are returned. Valid values range from `1` to `60`.
+`passed` | Boolean | Returns assignments where `data.passed` equals `passed`.
+`resurrected` | Boolean | Returns assignments where `data.resurrected` equals `resurrected`.
 `srs_stages` | Array of integers | Only assignments where `data.srs_stage` matches one of the array values are returned. Valid values range from `0` to `9`
+`started` | Boolean | When set to `true`, returns assignments that have a value in `data.started_at`. Returns assignments with a `null` `data.started_at` if `false`.
 `subject_ids` | Array of integers | Only assignments where `data.subject_id` matches one of the array values are returned.
 `subject_types` | Array of strings | Only assignments where `data.subject_type` matches one of the array values are returned. Valid values are: `radical`, `kanji`, or `vocabulary`.
 `unlocked` | Boolean | When set to `true`, returns assignments that have a value in `data.unlocked_at`. Returns assignments with a `null` `data.unlocked_at` if `false`.
-`started` | Boolean | When set to `true`, returns assignments that have a value in `data.started_at`. Returns assignments with a `null` `data.started_at` if `false`.
-`passed` | Boolean | Returns assignments where `data.passed` equals `passed`.
-`burned` | Boolean | When set to `true`, returns assignments that have a value in `data.burned_at`. Returns assignments with a `null` `data.burned_at` if `false`.
-`resurrected` | Boolean | Returns assignments where `data.resurrected` equals `resurrected`.
-`hidden` | Boolean | Return assignments with a matching value in the `hidden` attribute
 `updated_after` | Date | Only assignments updated after this time are returned.
-`in_review` | (not required) | Returns assignments which are in the review state
-`immediately_available_for_review` | (not required) | Returns assignments which are immediately available for review
-`immediately_available_for_lessons` | (not required) | Returns assignments which are immediately available for lessons
 
 ### Query Parameter Examples
 

--- a/source/includes/20170710/resources/_level_progressions.md.erb
+++ b/source/includes/20170710/resources/_level_progressions.md.erb
@@ -31,13 +31,13 @@ A level progression is created when a user has met the prerequisites for levelin
 
 Attribute | Possible Values | Description
 --------- | --------------- | -----------
+`abandoned_at` | `null` or Date | Timestamp when the user abandons the level. This is primary used when the user initiates a [reset](#resets).
+`completed_at` | `null` or Date | Timestamp when the user burns 100% of the assignments belonging to the associated subject's level.
 `created_at` | Date | Timestamp when the level progression is created
 `level` | Integer | The level of the progression, with possible values from `1` to `60`.
-`unlocked_at` | `null` or Date | Timestamp when the user can access lessons and reviews for the `level`.
-`started_at` | `null` or Date | Timestamp when the user starts their first lesson of a subject belonging to the level.
 `passed_at` | `null` or Date | Timestamp when the user passes at least 90% of the assignments with a type of `kanji` belonging to the associated subject's level.
-`completed_at` | `null` or Date | Timestamp when the user burns 100% of the assignments belonging to the associated subject's level.
-`abandoned_at` | `null` or Date | Timestamp when the user abandons the level. This is primary used when the user initiates a [reset](#resets).
+`started_at` | `null` or Date | Timestamp when the user starts their first lesson of a subject belonging to the level.
+`unlocked_at` | `null` or Date | Timestamp when the user can access lessons and reviews for the `level`.
 
 ## Get All Level Progressions
 

--- a/source/includes/20170710/resources/_resets.md.erb
+++ b/source/includes/20170710/resources/_resets.md.erb
@@ -26,10 +26,10 @@ Resets contain information about when those resets happen, the starting level, a
 
 Attribute | Data&nbsp;Type | Description
 --------- | --------------- | -----------
+`confirmed_at` | `null` or Date | Timestamp when the user confirmed the reset.
 `created_at` | Date | Timestamp when the reset was created.
 `original_level` | Integer | The user's level before the reset, from `1` to `60`
 `target_level` | Integer | The user's level after the reset, from `1` to `60`. It must be less than or equal to `original_level`.
-`confirmed_at` | `null` or Date | Timestamp when the user confirmed the reset.
 
 ## Get All Resets
 

--- a/source/includes/20170710/resources/_review_statistics.md.erb
+++ b/source/includes/20170710/resources/_review_statistics.md.erb
@@ -35,18 +35,18 @@ A review statistic is created when the user has done their first review on the r
 Attribute | Data&nbsp;Type | Description
 --------- | --------------- | -----------
 `created_at` | Date | Timestamp when the review statistic was created.
-`subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
-`subject_type` | String | The type of the associated [subject](#subjects), one of: `kanji`, `radical`, or `vocabulary`.
+`hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
 `meaning_correct` | Integer | Total number of correct answers submitted for the meaning of the associated subject.
+`meaning_current_streak` | Integer | The current, uninterrupted series of correct answers given for the meaning of the associated subject.
 `meaning_incorrect` | Integer | Total number of incorrect answers submitted for the meaning of the associated subject.
 `meaning_max_streak` | Integer | The longest, uninterrupted series of correct answers ever given for the meaning of the associated subject.
-`meaning_current_streak` | Integer | The current, uninterrupted series of correct answers given for the meaning of the associated subject.
+`percentage_correct` | Integer | The overall correct answer rate by the user for the subject, including both meaning and reading.
 `reading_correct` | Integer | Total number of correct answers submitted for the reading of the associated subject.
+`reading_current_streak` | Integer | The current, uninterrupted series of correct answers given for the reading of the associated subject.
 `reading_incorrect` | Integer | Total number of incorrect answers submitted for the reading of the associated subject.
 `reading_max_streak` | Integer | The longest, uninterrupted series of correct answers ever given for the reading of the associated subject.
-`reading_current_streak` | Integer | The current, uninterrupted series of correct answers given for the reading of the associated subject.
-`percentage_correct` | Integer | The overall correct answer rate by the user for the subject, including both meaning and reading.
-`hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
+`subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
+`subject_type` | String | The type of the associated [subject](#subjects), one of: `kanji`, `radical`, or `vocabulary`.
 
 ### Notes
 
@@ -111,12 +111,12 @@ The collection of review statistics will be filtered on the parameters provided.
 
 Name | Data&nbsp;Type | Description
 -- | -- | --
+`hidden` | Boolean | Return review statistics with a matching value in the `hidden` attribute
 `ids` | Array of integers | Only review statistics where `data.id` matches one of the array values are returned.
-`subject_ids` | Array of integers | Only review statistics where `data.subject_id` matches one of the array values are returned.
-`subject_types` | Array of strings | Only review statistics where `data.subject_type` matches one of the array values are returned. Valid values are: `radical`, `kanji`, or `vocabulary`.
 `percentages_greater_than` | Integer | Return review statistics where the `percentage_correct` is greater than the value.
 `percentages_less_than` | Integer | Return review statistics where the `percentage_correct` is less than the value.
-`hidden` | Boolean | Return review statistics with a matching value in the `hidden` attribute
+`subject_ids` | Array of integers | Only review statistics where `data.subject_id` matches one of the array values are returned.
+`subject_types` | Array of strings | Only review statistics where `data.subject_type` matches one of the array values are returned. Valid values are: `radical`, `kanji`, or `vocabulary`.
 `updated_after` | Date | Only review statistics updated after this time are returned.
 
 ## Get a Specific Review Statistic

--- a/source/includes/20170710/resources/_reviews.md.erb
+++ b/source/includes/20170710/resources/_reviews.md.erb
@@ -28,15 +28,15 @@ Reviews log all the correct and incorrect answers provided through the 'Reviews'
 
 Attribute | Date&nbsp;Type | Description
 --------- | --------------- | -----------
-`created_at` | Date | Timestamp when the review was created.
 `assignment_id` | Integer | Unique identifier of the associated [assignment](#assignments).
-`subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
-`starting_srs_stage` | Integer | The starting SRS stage interval, with valid values ranging from `1` to `8`
-`starting_srs_stage_name` | String | The [stage name](#srs-stage-intervals) associated with the `starting_srs_stage`.
-`ending_srs_stage` | Integer | The SRS stage interval calculated from the number of correct and incorrect answers, with valid values ranging from `1` to `9`
+`created_at` | Date | Timestamp when the review was created.
 `ending_srs_stage_name` | String | The [stage name](#srs-stage-intervals) associated with the `ending_srs_stage`.
+`ending_srs_stage` | Integer | The SRS stage interval calculated from the number of correct and incorrect answers, with valid values ranging from `1` to `9`
 `incorrect_meaning_answers` | Integer | The number of times the user has answered the meaning incorrectly.
 `incorrect_reading_answers` | Integer | The number of times the user has answered the reading incorrectly.
+`starting_srs_stage_name` | String | The [stage name](#srs-stage-intervals) associated with the `starting_srs_stage`.
+`starting_srs_stage` | Integer | The starting SRS stage interval, with valid values ranging from `1` to `8`
+`subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
 
 ### Notes
 
@@ -47,7 +47,6 @@ Subject type | Answer types allowed
 kanji        | Meaning, Reading
 radical      | Meaning
 vocabulary   | Meaning, Reading
-
 
 ## Get All Reviews
 
@@ -104,9 +103,9 @@ The collection of reviews will be filtered on the parameters provided.
 
 Name | Data Type | Description
 ---- | ---------------- | -----------
+`assignment_ids` | Array of integers | Only reviews where `data.assignment_id` matches one of the array values are returned.
 `ids` | Array of integers | Only reviews where `data.id` matches one of the array values are returned.
 `subject_ids` | Array of integers | Only reviews where `data.subject_id` matches one of the array values are returned.
-`assignment_ids` | Array of integers | Only reviews where `data.assignment_id` matches one of the array values are returned.
 `updated_after` | Date | Only reviews updated after this time are returned.
 
 ### Examples

--- a/source/includes/20170710/resources/_study_materials.md.erb
+++ b/source/includes/20170710/resources/_study_materials.md.erb
@@ -26,12 +26,12 @@ Study materials store user-specific notes and synonyms for a given subject. The 
 Attribute | Data&nbsp;Type | Description
 --------- | --------------- | -----------
 `created_at` | Date | Timestamp when the study material was created.
+`hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
+`meaning_note` | `null` or String | Free form note related to the meaning(s) of the associated subject.
+`meaning_synonyms` | Array | Synonyms for the meaning of the subject. These are used as additional correct answers during reviews.
+`reading_note` | `null` or String | Free form note related to the reading(s) of the associated subject.
 `subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
 `subject_type` | String | The type of the associated [subject](#subjects), one of: `kanji`, `radical`, or `vocabulary`.
-`meaning_note` | `null` or String | Free form note related to the meaning(s) of the associated subject.
-`reading_note` | `null` or String | Free form note related to the reading(s) of the associated subject.
-`meaning_synonyms` | Array | Synonyms for the meaning of the subject. These are used as additional correct answers during reviews.
-`hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
 
 ## Get All Study Materials
 
@@ -85,10 +85,10 @@ The collection of study material records will be filtered on the parameters prov
 
 Name | Data Type | Description
 ---- | ---------------- | -----------
+`hidden` | Boolean | Return study materials with a matching value in the `hidden` attribute
 `ids` | Array of integers | Only study material records where `data.id` matches one of the array values are returned.
 `subject_ids` | Array of integers | Only study material records where `data.subject_id` matches one of the array values are returned.
 `subject_types` | Array of strings | Only study material records where `data.subject_type` matches one of the array values are returned. Valid values are: `radical`, `kanji`, or `vocabulary`.
-`hidden` | Boolean | Return study materials with a matching value in the `hidden` attribute
 `updated_after` | Date | Only study material records updated after this time are returned.
 
 ### Examples

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -10,15 +10,16 @@ The exact structure of a subject depends on the subject type. The available subj
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`created_at` | Date | Timestamp when the subject was created.
-`level` | Integer | The level of the subject, from `1` to `60`.
-`slug` | String | The string that is used when generating the document URL for the subject. Radicals use their meaning, downcased. Kanji and vocabulary use their characters.
-`characters` | String | The UTF-8 characters for the subject, including kanji and hiragana.
-`meanings` | Array of objects | The subject meanings. See table below for the object structure.
-`meaning_mnemonic` | String | The subject's meaning mnemonic.
 `auxiliary_meanings` | Array of objects | Collection of auxiliary meanings. See table below for the object structure.
+`characters` | String | The UTF-8 characters for the subject, including kanji and hiragana.
+`created_at` | Date | Timestamp when the subject was created.
 `document_url` | String | A URL pointing to the page on wanikani.com that provides detailed information about this subject.
 `hidden_at` | Date | Timestamp when the subject was hidden, indicating associated assignments will no longer appear in lessons or reviews and that the subject page is no longer visible on wanikani.com.
+`level` | Integer | The level of the subject, from `1` to `60`.
+`lesson_position` | Integer | Default order in which the subject is presented in the WaniKani lesson feature, scoped by ascending subject `level`.
+`meaning_mnemonic` | String | The subject's meaning mnemonic.
+`meanings` | Array of objects | The subject meanings. See table below for the object structure.
+`slug` | String | The string that is used when generating the document URL for the subject. Radicals use their meaning, downcased. Kanji and vocabulary use their characters.
 
 #### Meaning Object Attributes
 

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -15,8 +15,8 @@ Attribute | Data Type | Description
 `created_at` | Date | Timestamp when the subject was created.
 `document_url` | String | A URL pointing to the page on wanikani.com that provides detailed information about this subject.
 `hidden_at` | Date | Timestamp when the subject was hidden, indicating associated assignments will no longer appear in lessons or reviews and that the subject page is no longer visible on wanikani.com.
+`lesson_position` | Integer | The position that the subject appears in lessons. Note that the value is scoped to the level of the subject, so there are duplicate values across levels.
 `level` | Integer | The level of the subject, from `1` to `60`.
-`lesson_position` | Integer | Default order in which the subject is presented in the WaniKani lesson feature, scoped by ascending subject `level`.
 `meaning_mnemonic` | String | The subject's meaning mnemonic.
 `meanings` | Array of objects | The subject meanings. See table below for the object structure.
 `slug` | String | The string that is used when generating the document URL for the subject. Radicals use their meaning, downcased. Kanji and vocabulary use their characters.

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -32,23 +32,23 @@ The user summary returns basic information for the user making the API request, 
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`username` | String | The user's username.
+`current_vacation_started_at` | `null` or Date | If the user is on vacation, this will be the timestamp of when that vacation started. If the user is not on vacation, this is `null`.
 `level` | Integer | The current level of the user. This ignores subscription status.
 `max_level_granted_by_subscription` | Integer | **NOTE: This will be dropped. Please use `subscription` instead.** The maximum level of content accessible to the user for lessons, reviews, and content review. For unsubscribed/free users, the maximum level is `3`. For subscribed users, this is `60`. **Any application that uses data from the WaniKani API must respect these access limits.**
 `profile_url` | String | The URL to the user's public facing profile page.
 `started_at` | Date | The signup date for the user.
 `subscribed` | Boolean | **NOTE: This will be dropped. Please use `subscription` instead.** Whether or not the user currently has a paid subscription.
-`current_vacation_started_at` | `null` or Date | If the user is on vacation, this will be the timestamp of when that vacation started. If the user is not on vacation, this is `null`.
 `subscription` | Object | Details about the user's subscription state. See table below for the object structure.
+`username` | String | The user's username.
 
 ### Subscription Object Attributes
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
 `active` | Boolean | Whether or not the user currently has a paid subscription.
-`type` | String | The type of subscription the user has. Options are following: `free`, `recurring`, and `lifetime`.
 `max_level_granted` | Integer | The maximum level of content accessible to the user for lessons, reviews, and content review. For unsubscribed/free users, the maximum level is `3`. For subscribed users, this is `60`. **Any application that uses data from the WaniKani API must respect these access limits.**
 `period_ends_at` | `null` or Date | The date when the user's subscription period ends. If the user has subscription type `lifetime` or `free` then the value is `null`.
+`type` | String | The type of subscription the user has. Options are following: `free`, `recurring`, and `lifetime`.
 
 ## Get User Information
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add information about new subject attribute `lesson_position`
* Order table rows by alphabetical

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
