### PR TITLE
Add user preferences information

### DIFF
--- a/source/examples/_PUT_javascript.erb
+++ b/source/examples/_PUT_javascript.erb
@@ -1,0 +1,21 @@
+```javascript
+var apiToken = '<%= locals.fetch(:api_token, current_page.data.api_token_placeholder) %>';
+var apiEndpointPath = '<%= locals.fetch(:api_endpoint, current_page.data.api_endpoint_placeholder) %>';
+var requestHeaders =
+  new Headers({
+    <% unless locals.fetch(:without_revision, false) %>
+    'Wanikani-Revision': '<%= current_page.data.api_revision %>',
+    <% end %>
+    Authorization: 'Bearer ' + apiToken,
+  });
+var apiEndpoint =
+  new Request('<%= current_page.data.api_root_url %>/' + apiEndpointPath, {
+    method: 'PUT',
+    headers: requestHeaders,
+    body: <%= JSON.pretty_generate(locals.fetch(:params, {})) %>
+  });
+
+fetch(apiEndpoint)
+  .then(response => response.json())
+  .then(responseBody => console.log(responseBody));
+```

--- a/source/examples/_PUT_shell.erb
+++ b/source/examples/_PUT_shell.erb
@@ -1,0 +1,10 @@
+```shell
+curl "<%= current_page.data.api_root_url %>/<%= locals.fetch(:api_endpoint, current_page.data.api_endpoint_placeholder) %>" \
+  -X "PUT" \
+  <% unless locals.fetch(:without_revision, false) %>
+  -H "Wanikani-Revision: <%= current_page.data.api_revision %>" \
+  <% end %>
+  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Authorization: Bearer <%= locals.fetch(:api_token, current_page.data.api_token_placeholder) %>"
+  -d $'<%= JSON.pretty_generate(locals.fetch(:params, {})) %>'
+```

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -53,7 +53,7 @@ Attribute | Data Type | Description
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`lessons_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during lessons.
+`lessons_autoplay_audio` | Boolean | Automatically play pronunciation audio for vocabulary during lessons.
 `lessons_batch_size` | Integer | Number of subjects introduced to the user during lessons before quizzing.
 `lessons_presentation_order` | String | The order in which lessons are presented. The options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. The default (and best experience) is `ascending_level_then_subject`.
 `reviews_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during reviews.

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -100,7 +100,7 @@ Attribute | Data Type | Description
     },
     "preferences": {
       "lessons_autoplay_audio": false,
-      "lessons_batch_size": 10,
+      "lessons_batch_size": 5,
       "lessons_presentation_order": "ascending_level_then_subject",
       "reviews_autoplay_audio": false,
       "reviews_display_srs_indicator": true

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -55,7 +55,7 @@ Attribute | Data Type | Description
 --------- | --------------- | -----------
 `lessons_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during lessons.
 `lessons_batch_size` | Integer | Number of subjects introduced to the user during lessons before quizzing.
-`lessons_presentation_order` | String | The order lessons are presented. Options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. WaniKani default (and preferred for best experience) is `ascending_level_then_subject`.
+`lessons_presentation_order` | String | The order in which lessons are presented. The options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. The default (and best experience) is `ascending_level_then_subject`.
 `reviews_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during reviews.
 `reviews_display_srs_indicator` | Boolean | Toggle for display SRS change indicator after a subject has been completely answered during review.
 

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -54,7 +54,7 @@ Attribute | Data Type | Description
 Attribute | Data Type | Description
 --------- | --------------- | -----------
 `lessons_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during lessons.
-`lessons_batch_size` | Integer | Number of subjects introduce to the user during lessons before quizzing.
+`lessons_batch_size` | Integer | Number of subjects introduced to the user during lessons before quizzing.
 `lessons_presentation_order` | String | The order lessons are presented. Options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. WaniKani default (and preferred for best experience) is `ascending_level_then_subject`.
 `reviews_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during reviews.
 `reviews_display_srs_indicator` | Boolean | Toggle for display SRS change indicator after a subject has been completely answered during review.

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -25,6 +25,13 @@ The user summary returns basic information for the user making the API request, 
       "type": "recurring",
       "max_level_granted": 60,
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
+    },
+    "preferences": {
+      "lessons_autoplay_audio": false,
+      "lessons_batch_size": 10,
+      "lessons_presentation_order": "ascending_level_then_subject",
+      "reviews_autoplay_audio": false,
+      "reviews_display_srs_indicator": true
     }
   }
 }
@@ -35,11 +42,22 @@ Attribute | Data Type | Description
 `current_vacation_started_at` | `null` or Date | If the user is on vacation, this will be the timestamp of when that vacation started. If the user is not on vacation, this is `null`.
 `level` | Integer | The current level of the user. This ignores subscription status.
 `max_level_granted_by_subscription` | Integer | **NOTE: This will be dropped. Please use `subscription` instead.** The maximum level of content accessible to the user for lessons, reviews, and content review. For unsubscribed/free users, the maximum level is `3`. For subscribed users, this is `60`. **Any application that uses data from the WaniKani API must respect these access limits.**
+`preferences` | Object | User settings specific to the WaniKani application. See table below for the object structure.
 `profile_url` | String | The URL to the user's public facing profile page.
 `started_at` | Date | The signup date for the user.
 `subscribed` | Boolean | **NOTE: This will be dropped. Please use `subscription` instead.** Whether or not the user currently has a paid subscription.
 `subscription` | Object | Details about the user's subscription state. See table below for the object structure.
 `username` | String | The user's username.
+
+### Preferences Object Attributes
+
+Attribute | Data Type | Description
+--------- | --------------- | -----------
+`lessons_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during lessons.
+`lessons_batch_size` | Integer | Number of subjects introduce to the user during lessons before quizzing.
+`lessons_presentation_order` | String | The order lessons are presented. Options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. WaniKani default (and preferred for best experience) is `ascending_level_then_subject`.
+`reviews_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during reviews.
+`reviews_display_srs_indicator` | Boolean | Toggle for display SRS change indicator after a subject has been completely answered during review.
 
 ### Subscription Object Attributes
 
@@ -79,6 +97,13 @@ Attribute | Data Type | Description
       "type": "recurring",
       "max_level_granted": 60,
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
+    },
+    "preferences": {
+      "lessons_autoplay_audio": false,
+      "lessons_batch_size": 10,
+      "lessons_presentation_order": "ascending_level_then_subject",
+      "reviews_autoplay_audio": false,
+      "reviews_display_srs_indicator": true
     }
   }
 }
@@ -89,3 +114,62 @@ Returns a summary of user information.
 ### HTTP Request
 
 `GET <%= current_page.data.api_root_url %>/user`
+
+## Update User Information
+
+> Example Request
+
+<%= partial('examples/PUT_shell', locals: { api_endpoint: 'user', params: { "user": { "preferences": { "lessons_autoplay_audio": true, "lessons_batch_size": 3, "lessons_presentation_order": "shuffled", "reviews_autoplay_audio": true, "reviews_display_srs_indicator": false } } } }) %>
+
+<%= partial('examples/PUT_javascript', locals: { api_endpoint: 'user', params: { "user": { "preferences": { "lessons_autoplay_audio": true, "lessons_batch_size": 3, "lessons_presentation_order": "shuffled", "reviews_autoplay_audio": true, "reviews_display_srs_indicator": false } } } }) %>
+
+> Example Response
+
+```json
+{
+  "object": "user",
+  "url": "<%= current_page.data.api_root_url %>/user",
+  "data_updated_at": "2018-04-06T14:26:53.022245Z",
+  "data": {
+    "id": "5a6a5234-a392-4a87-8f3f-33342afe8a42",
+    "username": "example_user",
+    "level": 5,
+    "max_level_granted_by_subscription": 60,
+    "profile_url": "https://www.wanikani.com/users/example_user",
+    "started_at": "2012-05-11T00:52:18.958466Z",
+    "subscribed": true,
+    "current_vacation_started_at": null,
+    "subscription": {
+      "active": true,
+      "type": "recurring",
+      "max_level_granted": 60,
+      "period_ends_at": "2018-12-11T13:32:19.485748Z"
+    },
+    "preferences": {
+      "lessons_autoplay_audio": true,
+      "lessons_batch_size": 3,
+      "lessons_presentation_order": "shuffled",
+      "reviews_autoplay_audio": true,
+      "reviews_display_srs_indicator": false
+    }
+  }
+}
+```
+
+Returns an updated summary of user information.
+
+### HTTP Request
+
+`PUT <%= current_page.data.api_root_url %>/user`
+
+### Allowed Parameters
+
+Only the values under `preferences` are allowed to be updated.
+
+Name | Data Type | Required?
+---- | --------- | ---------
+`lessons_autoplay_audio` | Boolean | false
+`lessons_batch_size` | Integer | false
+`lessons_presentation_order` | String | false
+`reviews_autoplay_audio` | Boolean | false
+`reviews_display_srs_indicator` | Boolean | false

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -56,7 +56,7 @@ Attribute | Data Type | Description
 `lessons_autoplay_audio` | Boolean | Automatically play pronunciation audio for vocabulary during lessons.
 `lessons_batch_size` | Integer | Number of subjects introduced to the user during lessons before quizzing.
 `lessons_presentation_order` | String | The order in which lessons are presented. The options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. The default (and best experience) is `ascending_level_then_subject`.
-`reviews_autoplay_audio` | Boolean | Toggle for autoplaying pronunciation audio during reviews.
+`reviews_autoplay_audio` | Boolean | Automatically play pronunciation audio for vocabulary during reviews.
 `reviews_display_srs_indicator` | Boolean | Toggle for display SRS change indicator after a subject has been completely answered during review.
 
 ### Subscription Object Attributes


### PR DESCRIPTION
Changes proposed in this pull request:

* Added information about preferences under `/user`

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
