### PR TITLE
Added /assignment/:id/learned

### DIFF
--- a/source/examples/_PUT_javascript.erb
+++ b/source/examples/_PUT_javascript.erb
@@ -12,7 +12,7 @@ var apiEndpoint =
   new Request('<%= current_page.data.api_root_url %>/' + apiEndpointPath, {
     method: 'PUT',
     headers: requestHeaders,
-    body: <%= JSON.pretty_generate(locals.fetch(:params, {})) %>
+    body: <% JSON.pretty_generate(locals.fetch(:params, {})).each_line.with_index do |line, index| %><%= index.positive? ? '    ' + line : line %><% end %>
   });
 
 fetch(apiEndpoint)

--- a/source/examples/_PUT_shell.erb
+++ b/source/examples/_PUT_shell.erb
@@ -5,6 +5,6 @@ curl "<%= current_page.data.api_root_url %>/<%= locals.fetch(:api_endpoint, curr
   -H "Wanikani-Revision: <%= current_page.data.api_revision %>" \
   <% end %>
   -H 'Content-Type: application/json; charset=utf-8' \
-  -H "Authorization: Bearer <%= locals.fetch(:api_token, current_page.data.api_token_placeholder) %>"
+  -H "Authorization: Bearer <%= locals.fetch(:api_token, current_page.data.api_token_placeholder) %>" \
   -d $'<%= JSON.pretty_generate(locals.fetch(:params, {})) %>'
 ```

--- a/source/examples/_PUT_shell.erb
+++ b/source/examples/_PUT_shell.erb
@@ -4,7 +4,7 @@ curl "<%= current_page.data.api_root_url %>/<%= locals.fetch(:api_endpoint, curr
   <% unless locals.fetch(:without_revision, false) %>
   -H "Wanikani-Revision: <%= current_page.data.api_revision %>" \
   <% end %>
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   -H "Authorization: Bearer <%= locals.fetch(:api_token, current_page.data.api_token_placeholder) %>" \
-  -d $'<%= JSON.pretty_generate(locals.fetch(:params, {})) %>'
+  -d $'<% JSON.pretty_generate(locals.fetch(:params, {})).each_line.with_index do |line, index| %><%= index.positive? ? '     ' + line : line %><% end %>'
 ```

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -218,7 +218,7 @@ Attribute | New Value
 
 > Example Request
 
-<%= partial('examples/PUT_shell', locals: { api_endpoint: 'assignments/80463006/learned' }) %>
+<%= partial('examples/PUT_shell', locals: { api_endpoint: 'assignments/80463006/start' }) %>
 
 <%= partial('examples/PUT_javascript', locals: { api_endpoint: 'assignments/80463006/start' }) %>
 

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -220,7 +220,7 @@ Attribute | New Value
 
 <%= partial('examples/PUT_shell', locals: { api_endpoint: 'assignments/80463006/learned' }) %>
 
-<%= partial('examples/PUT_javascript', locals: { api_endpoint: 'assignments/80463006/learned' }) %>
+<%= partial('examples/PUT_javascript', locals: { api_endpoint: 'assignments/80463006/start' }) %>
 
 > Example Response
 

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -202,7 +202,7 @@ The assignment must be in the following valid state:
 
 Attribute | State
 --------- | -----
-`level` | Must be less than or equal to the lower value between [User's](#user-data-structure) `level` and `max_level_granted_by_subscription`
+`level` | Must be less than or equal to the lowest value of [User's](#user-data-structure) `level` and `max_level_granted_by_subscription`
 `srs_stage` | Must be equal to `0`
 `started_at` | Must be equal to `null`
 `unlocked_at` | Must not be `null`

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -194,7 +194,7 @@ Name | Data Type | Description
 The `unlocked_at`, `started_at`, `passed_at`, and `burned_at` timestamps are always in sequential order — assignments can't be started before they're unlocked, passed before they're started, etc.
 
 
-## Learned Assignment
+## Start an Assignment
 
 Update the assignment's state to "review". Typically used after the user has learned the associated subject in lessons.
 

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -192,3 +192,65 @@ Name | Data Type | Description
 ### Notes
 
 The `unlocked_at`, `started_at`, `passed_at`, and `burned_at` timestamps are always in sequential order — assignments can't be started before they're unlocked, passed before they're started, etc.
+
+
+## Learned Assignment
+
+Update the assignment's state to "review". Typically used after the user has learned the associated subject in lessons.
+
+Assignment must be in the following valid state:
+
+Attribute | State
+--------- | -----
+`level` | Must be less than or equal to the lower value between [User's](#user-data-structure) `level` and `max_level_granted_by_subscription`
+`srs_stage` | Must be equal to `0`
+`started_at` | Must be equal to `null`
+`unlocked_at` | Must not be `null`
+
+The following attributes are updated:
+
+Attribute | New Value
+--------- | ---------
+`available_at` | ISO8601 String timestamp
+`srs_stage_name` | `Apprentice I`
+`srs_stage` | `1`
+`started_at` | ISO8601 String timestamp
+
+> Example Request
+
+<%= partial('examples/PUT_shell', locals: { api_endpoint: 'assignments/80463006/learned' }) %>
+
+<%= partial('examples/PUT_javascript', locals: { api_endpoint: 'assignments/80463006/learned' }) %>
+
+> Example Response
+
+```json
+{
+  "id": 80463006,
+  "object": "assignment",
+  "url": "<%= current_page.data.api_root_url %>/assignments/80463006",
+  "data_updated_at": "2017-11-29T19:37:03.571377Z",
+  "data": {
+    "created_at": "2017-09-05T23:38:10.695133Z",
+    "subject_id": 8761,
+    "subject_type": "radical",
+    "level": 1,
+    "srs_stage": 1,
+    "srs_stage_name": "Apprentice I",
+    "unlocked_at": "2017-09-05T23:38:10.695133Z",
+    "started_at": "2017-09-05T23:41:28.980679Z",
+    "passed_at": null,
+    "burned_at": null,
+    "available_at": "2018-02-27T00:00:00.000000Z",
+    "passed": false,
+    "resurrected_at": null,
+    "resurrected": false
+  }
+}
+```
+
+Returns the updated assignment.
+
+### HTTP Request
+
+`PUT <%= current_page.data.api_root_url %>/assignments/<id>/learned`

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -253,4 +253,4 @@ Returns the updated assignment.
 
 ### HTTP Request
 
-`PUT <%= current_page.data.api_root_url %>/assignments/<id>/learned`
+`PUT <%= current_page.data.api_root_url %>/assignments/<id>/start`

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -198,7 +198,7 @@ The `unlocked_at`, `started_at`, `passed_at`, and `burned_at` timestamps are alw
 
 Mark the assignment as started, moving the assignment from the lessons queue to the review queue. 
 
-Assignment must be in the following valid state:
+The assignment must be in the following valid state:
 
 Attribute | State
 --------- | -----

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -196,7 +196,7 @@ The `unlocked_at`, `started_at`, `passed_at`, and `burned_at` timestamps are alw
 
 ## Start an Assignment
 
-Update the assignment's state to "review". Typically used after the user has learned the associated subject in lessons.
+Mark the assignment as started, moving the assignment from the lessons queue to the review queue. 
 
 Assignment must be in the following valid state:
 

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -196,31 +196,11 @@ The `unlocked_at`, `started_at`, `passed_at`, and `burned_at` timestamps are alw
 
 ## Start an Assignment
 
-Mark the assignment as started, moving the assignment from the lessons queue to the review queue. 
-
-The assignment must be in the following valid state:
-
-Attribute | State
---------- | -----
-`level` | Must be less than or equal to the lowest value of [User's](#user-data-structure) `level` and `max_level_granted_by_subscription`
-`srs_stage` | Must be equal to `0`
-`started_at` | Must be equal to `null`
-`unlocked_at` | Must not be `null`
-
-The following attributes are updated:
-
-Attribute | New Value
---------- | ---------
-`available_at` | ISO8601 String timestamp
-`srs_stage_name` | `Apprentice I`
-`srs_stage` | `1`
-`started_at` | ISO8601 String timestamp
-
 > Example Request
 
-<%= partial('examples/PUT_shell', locals: { api_endpoint: 'assignments/80463006/start' }) %>
+<%= partial('examples/PUT_shell', locals: { api_endpoint: 'assignments/80463006/start', params: { 'started_at': '2017-09-05T23:41:28.980679Z' } }) %>
 
-<%= partial('examples/PUT_javascript', locals: { api_endpoint: 'assignments/80463006/start' }) %>
+<%= partial('examples/PUT_javascript', locals: { api_endpoint: 'assignments/80463006/start', params: { 'started_at': '2017-09-05T23:41:28.980679Z' } }) %>
 
 > Example Response
 
@@ -249,8 +229,40 @@ Attribute | New Value
 }
 ```
 
-Returns the updated assignment.
+Mark the assignment as started, moving the assignment from the lessons queue to the review queue. Returns the updated assignment.
 
 ### HTTP Request
 
 `PUT <%= current_page.data.api_root_url %>/assignments/<id>/start`
+
+### Allowed Parameters
+
+Name | Data Type | Required?
+---- | --------- | ---------
+`started_at` | Date | false
+
+Notes:
+
+* If not set, `started_at` will default to the time the request is made.
+* `started_at` must be greater than or equal to `unlocked_at`.
+
+
+### Expected Starting State
+
+The assignment must be in the following valid state:
+
+Attribute | State
+--------- | -----
+`level` | Must be less than or equal to the lowest value of [User's](#user-data-structure) `level` and `max_level_granted_by_subscription`
+`srs_stage` | Must be equal to `0`
+`started_at` | Must be equal to `null`
+`unlocked_at` | Must not be `null`
+
+### Updated Attributes
+
+Attribute | New Value
+--------- | ---------
+`available_at` | ISO8601 String timestamp
+`srs_stage_name` | `Apprentice I`
+`srs_stage` | `1`
+`started_at` | ISO8601 String timestamp


### PR DESCRIPTION
NOTE: Relies on #4 

Changes proposed in this pull request:

* Added PUT `/assignment/:id/learned`. Used to update state of assignments from lesson to review 

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
