### PR TITLE
Fix typo with radical auxiliary meanings; sort lists alphabetically

### DIFF
--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -66,11 +66,17 @@ The strings can include a WaniKani specific markup syntax. The following is a li
   "url": "<%= current_page.data.api_root_url %>/subjects/1",
   "data_updated_at": "2018-03-29T23:13:14.064836Z",
   "data": {
-    "created_at": "2012-02-27T18:08:16.000000Z",
-    "level": 1,
-    "slug": "ground",
-    "hidden_at": null,
-    "document_url": "https://www.wanikani.com/radicals/ground",
+    "amalgamation_subject_ids": [
+      5,
+      4,
+      98
+    ],
+    "auxiliary_meanings": [
+      {
+        "meaning": "grund",
+        "type": "blacklist"
+      }
+    ],
     "characters": "一",
     "character_images": [
       {
@@ -81,6 +87,11 @@ The strings can include a WaniKani specific markup syntax. The following is a li
         "content_type": "image/svg+xml"
       }
     ],
+    "created_at": "2012-02-27T18:08:16.000000Z",
+    "document_url": "https://www.wanikani.com/radicals/ground",
+    "hidden_at": null,
+    "lesson_position": 1
+    "level": 1,
     "meanings": [
       {
         "meaning": "Ground",
@@ -89,18 +100,7 @@ The strings can include a WaniKani specific markup syntax. The following is a li
       }
     ],
     "meaning_mnemonic": "This radical consists of a single, horizontal stroke. What's the biggest, single, horizontal stroke? That's the ground. Look at the <radical>ground</radical>, look at this radical, now look at the ground again. Kind of the same, right?",
-    "auxiliary_meanings": [
-      {
-        "meaning": "one", "type": "blacklist",
-        "meaning": "flat", "type": "whitelist"
-      }
-    ]
-    "amalgamation_subject_ids": [
-      5,
-      4,
-      98
-    ],
-    "lesson_position": 1
+    "slug": "ground",
   }
 }
 ```
@@ -132,12 +132,30 @@ Attribute | Data Type | Description
   "url": "<%= current_page.data.api_root_url %>/subjects/440",
   "data_updated_at": "2018-03-29T23:14:30.805034Z",
   "data": {
-    "created_at": "2012-02-27T19:55:19.000000Z",
-    "level": 1,
-    "slug": "一",
-    "hidden_at": null,
-    "document_url": "https://www.wanikani.com/kanji/%E4%B8%80",
+    "amalgamation_subject_ids": [
+      56,
+      88,
+      91
+    ],
+    "auxiliary_meanings": [
+      {
+        "meaning": "one",
+        "type": "blacklist"
+      },
+      {
+        "meaning": "flat",
+        "type": "whitelist"
+      }
+    ],
     "characters": "一",
+    "component_subject_ids": [
+      1
+    ],
+    "created_at": "2012-02-27T19:55:19.000000Z",
+    "document_url": "https://www.wanikani.com/kanji/%E4%B8%80",
+    "hidden_at": null,
+    "lesson_position": 2
+    "level": 1,
     "meanings": [
       {
         "meaning": "One",
@@ -145,6 +163,8 @@ Attribute | Data Type | Description
         "accepted_answer": true
       }
     ],
+    "meaning_hint": "To remember the meaning of <kanji>One</kanji>, imagine yourself there at the scene of the crime. You grab <kanji>One</kanji> in your arms, trying to prop it up, trying to hear its last words. Instead, it just splatters some blood on your face. "Who did this to you?" you ask. The number One points weakly, and you see number Two running off into an alleyway. He's always been jealous of number One and knows he can be number one now that he's taken the real number one out.",
+    "meaning_mnemonic": "Lying on the <radical>ground</radical> is something that looks just like the ground, the number <kanji>One</kanji>. Why is this One lying down? It's been shot by the number two. It's lying there, bleeding out and dying. The number One doesn't have long to live.",
     "readings": [
       {
         "type": "onyomi",
@@ -165,20 +185,10 @@ Attribute | Data Type | Description
         "reading": "かず"
       }
     ],
-    "component_subject_ids": [
-      1
-    ],
-    "amalgamation_subject_ids": [
-      56,
-      88,
-      91
-    ],
-    "visually_similar_subject_ids": [],
-    "meaning_mnemonic": "Lying on the <radical>ground</radical> is something that looks just like the ground, the number <kanji>One</kanji>. Why is this One lying down? It's been shot by the number two. It's lying there, bleeding out and dying. The number One doesn't have long to live.",
-    "meaning_hint": "To remember the meaning of <kanji>One</kanji>, imagine yourself there at the scene of the crime. You grab <kanji>One</kanji> in your arms, trying to prop it up, trying to hear its last words. Instead, it just splatters some blood on your face. "Who did this to you?" you ask. The number One points weakly, and you see number Two running off into an alleyway. He's always been jealous of number One and knows he can be number one now that he's taken the real number one out.",
     "reading_mnemonic": "As you're sitting there next to <kanji>One</kanji>, holding him up, you start feeling a weird sensation all over your skin. From the wound comes a fine powder (obviously coming from the special bullet used to kill One) that causes the person it touches to get extremely <reading>itchy</reading> (いち)",
     "reading_hint": "Make sure you feel the ridiculously <reading>itchy</reading> sensation covering your body. It climbs from your hands, where you're holding the number <kanji>One</kanji> up, and then goes through your arms, crawls up your neck, goes down your body, and then covers everything. It becomes uncontrollable, and you're scratching everywhere, writhing on the ground. It's so itchy that it's the most painful thing you've ever experienced (you should imagine this vividly, so you remember the reading of this kanji).",
-    "lesson_position": 2
+    "slug": "一",
+    "visually_similar_subject_ids": [],
   }
 }
 ```
@@ -212,35 +222,13 @@ Attribute | Data Type | Description
   "url": "<%= current_page.data.api_root_url %>/subjects/2467",
   "data_updated_at": "2018-12-12T23:09:52.234049Z",
   "data": {
-    "created_at": "2012-02-28T08:04:47.000000Z",
-    "level": 1,
-    "slug": "一",
-    "hidden_at": null,
-    "document_url": "https://www.wanikani.com/vocabulary/%E4%B8%80",
-    "characters": "一",
-    "meanings": [
-      {
-        "meaning": "One",
-        "primary": true,
-        "accepted_answer": true
-      }
-    ],
     "auxiliary_meanings": [
       {
         "type": "whitelist",
         "meaning": "1"
       }
     ],
-    "readings": [
-      {
-        "primary": true,
-        "reading": "いち",
-        "accepted_answer": true
-      }
-    ],
-    "parts_of_speech": [
-      "numeral"
-    ],
+    "characters": "一",
     "component_subject_ids": [
       440
     ],
@@ -258,35 +246,57 @@ Attribute | Data Type | Description
         "ja": "ぼくはせかいで一ばんよわい。"
       }
     ],
+    "created_at": "2012-02-28T08:04:47.000000Z",
+    "document_url": "https://www.wanikani.com/vocabulary/%E4%B8%80",
+    "hidden_at": null,
+    "lesson_position": 44,
+    "level": 1,
+    "meanings": [
+      {
+        "meaning": "One",
+        "primary": true,
+        "accepted_answer": true
+      }
+    ],
+    "meaning_mnemonic": "As is the case with most vocab words that consist of a single kanji, this vocab word has the same meaning as the kanji it parallels, which is \u003cvocabulary\u003eone\u003c/vocabulary\u003e.",
+    "parts_of_speech": [
+      "numeral"
+    ],
     "pronunciation_audios": [
       {
-        "url": "https://cdn.wanikani.com/audios/1838-subject-2467.mp3?1536694949",
-        "metadata":
-        {
+        "url": "https://cdn.wanikani.com/audios/3020-subject-2467.mp3?1547862356",
+        "metadata": {
           "gender": "male",
-          "source_id": 840,
+          "source_id": 2711,
           "pronunciation": "いち",
           "voice_actor_id": 2,
-          "voice_actor_name": "Tarou",
-          "voice_description": "Standard voice"
+          "voice_actor_name": "Kenichi",
+          "voice_description": "Tokyo accent"
         },
         "content_type": "audio/mpeg"
       },
       {
-        "url": "https://cdn.wanikani.com/audios/1834-subject-2467.ogg?1536694948",
-        "metadata":
-        {
+        "url": "https://cdn.wanikani.com/audios/3018-subject-2467.ogg?1547862356",
+        "metadata": {
           "gender": "male",
-          "source_id": 840,
+          "source_id": 2711,
           "pronunciation": "いち",
           "voice_actor_id": 2,
-          "voice_actor_name": "Tarou",
-          "voice_description": "Standard voice"
+          "voice_actor_name": "Kenichi",
+          "voice_description": "Tokyo accent"
         },
         "content_type": "audio/ogg"
       }
     ],
-    "lesson_position": 1
+    "readings": [
+      {
+        "primary": true,
+        "reading": "いち",
+        "accepted_answer": true
+      }
+    ],
+    "reading_mnemonic": "When a vocab word is all alone and has no okurigana (hiragana attached to kanji) connected to it, it usually uses the kun'yomi reading. Numbers are an exception, however. When a number is all alone, with no kanji or okurigana, it is going to be the on'yomi reading, which you learned with the kanji.  Just remember this exception for alone numbers and you'll be able to read future number-related vocab to come.",
+    "slug": "一",
   }
 }
 ```
@@ -294,20 +304,20 @@ Attribute | Data Type | Description
 Attribute | Data Type | Description
 --------- | --------------- | -----------
 `component_subject_ids` | Array of integers | An array of numeric identifiers for the kanji that make up this vocabulary. Note that these are the subjects that must be have passed assignments in order to unlock this subject's assignment.
-`readings` | Array of objects | Selected readings for the vocabulary. See table below for the object structure.
-`parts_of_speech` | Array of strings | Parts of speech.
-`meaning_mnemonic` | String | The subject's meaning mnemonic.
-`reading_mnemonic` | String | The subject's reading mnemonic.
 `context_sentences` | Array of objects | A collection of context sentences. See table below for the object structure.
+`meaning_mnemonic` | String | The subject's meaning mnemonic.
+`parts_of_speech` | Array of strings | Parts of speech.
 `pronunciation_audios` | Array of objects | A collection of pronunciation audio. See table below for the object structure.
+`readings` | Array of objects | Selected readings for the vocabulary. See table below for the object structure.
+`reading_mnemonic` | String | The subject's reading mnemonic.
 
 #### Reading Object Attributes
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`reading` | String | A singular subject reading.
-`primary` | Boolean | Indicates priority in the WaniKani system.
 `accepted_answer` | Boolean | Indicates if the reading is used to evaluate user input for correctness.
+`primary` | Boolean | Indicates priority in the WaniKani system.
+`reading` | String | A singular subject reading.
 
 #### Context Sentence Object Attributes
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix a typo in the auxiliary meaning structure of the example radical response
* Sort example response attributes and a couple tables of attributes alphabetically

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
