### PR TITLE
Add default_voice_actor to user.preferences

### DIFF
--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -172,7 +172,7 @@ Only the values under `preferences` are allowed to be updated.
 
 Name | Data Type | Required?
 ---- | --------- | ---------
-`default_voice_actor` | Integer | 1
+`default_voice_actor` | Integer | false
 `lessons_autoplay_audio` | Boolean | false
 `lessons_batch_size` | Integer | false
 `lessons_presentation_order` | String | false

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -27,7 +27,7 @@ The user summary returns basic information for the user making the API request, 
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
     },
     "preferences": {
-      "default_voice_actor": 1,
+      "default_voice_actor_id": 1,
       "lessons_autoplay_audio": false,
       "lessons_batch_size": 10,
       "lessons_presentation_order": "ascending_level_then_subject",
@@ -54,7 +54,7 @@ Attribute | Data Type | Description
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`default_voice_actor` | Integer | The voice actor to be used for lessons and reviews. The value is associated to `subject.pronunciation_audios.metadata.voice_actor_id`.
+`default_voice_actor_id` | Integer | The voice actor to be used for lessons and reviews. The value is associated to `subject.pronunciation_audios.metadata.voice_actor_id`.
 `lessons_autoplay_audio` | Boolean | Automatically play pronunciation audio for vocabulary during lessons.
 `lessons_batch_size` | Integer | Number of subjects introduced to the user during lessons before quizzing.
 `lessons_presentation_order` | String | The order in which lessons are presented. The options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. The default (and best experience) is `ascending_level_then_subject`.
@@ -101,7 +101,7 @@ Attribute | Data Type | Description
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
     },
     "preferences": {
-      "default_voice_actor": 1,
+      "default_voice_actor_id": 1,
       "lessons_autoplay_audio": false,
       "lessons_batch_size": 5,
       "lessons_presentation_order": "ascending_level_then_subject",
@@ -149,7 +149,7 @@ Returns a summary of user information.
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
     },
     "preferences": {
-      "default_voice_actor": 1,
+      "default_voice_actor_id": 1,
       "lessons_autoplay_audio": true,
       "lessons_batch_size": 3,
       "lessons_presentation_order": "shuffled",
@@ -172,7 +172,7 @@ Only the values under `preferences` are allowed to be updated.
 
 Name | Data Type | Required?
 ---- | --------- | ---------
-`default_voice_actor` | Integer | false
+`default_voice_actor_id` | Integer | false
 `lessons_autoplay_audio` | Boolean | false
 `lessons_batch_size` | Integer | false
 `lessons_presentation_order` | String | false

--- a/source/includes/20170710/resources/_user.md.erb
+++ b/source/includes/20170710/resources/_user.md.erb
@@ -27,6 +27,7 @@ The user summary returns basic information for the user making the API request, 
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
     },
     "preferences": {
+      "default_voice_actor": 1,
       "lessons_autoplay_audio": false,
       "lessons_batch_size": 10,
       "lessons_presentation_order": "ascending_level_then_subject",
@@ -53,6 +54,7 @@ Attribute | Data Type | Description
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
+`default_voice_actor` | Integer | The voice actor to be used for lessons and reviews. The value is associated to `subject.pronunciation_audios.metadata.voice_actor_id`.
 `lessons_autoplay_audio` | Boolean | Automatically play pronunciation audio for vocabulary during lessons.
 `lessons_batch_size` | Integer | Number of subjects introduced to the user during lessons before quizzing.
 `lessons_presentation_order` | String | The order in which lessons are presented. The options are `ascending_level_then_subject`, `shuffled`, and `ascending_level_then_shuffled`. The default (and best experience) is `ascending_level_then_subject`.
@@ -99,6 +101,7 @@ Attribute | Data Type | Description
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
     },
     "preferences": {
+      "default_voice_actor": 1,
       "lessons_autoplay_audio": false,
       "lessons_batch_size": 5,
       "lessons_presentation_order": "ascending_level_then_subject",
@@ -146,6 +149,7 @@ Returns a summary of user information.
       "period_ends_at": "2018-12-11T13:32:19.485748Z"
     },
     "preferences": {
+      "default_voice_actor": 1,
       "lessons_autoplay_audio": true,
       "lessons_batch_size": 3,
       "lessons_presentation_order": "shuffled",
@@ -168,6 +172,7 @@ Only the values under `preferences` are allowed to be updated.
 
 Name | Data Type | Required?
 ---- | --------- | ---------
+`default_voice_actor` | Integer | 1
 `lessons_autoplay_audio` | Boolean | false
 `lessons_batch_size` | Integer | false
 `lessons_presentation_order` | String | false


### PR DESCRIPTION
Changes proposed in this pull request:

* Add default_voice_actor to user.preferences

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed