### PR TITLE
fix(urls): fix a few links

### DIFF
--- a/source/20170710/index.html.md
+++ b/source/20170710/index.html.md
@@ -6,7 +6,7 @@ api_root_url: 'https://api.wanikani.com/v2'
 api_token_placeholder: '<api_token_here>'
 api_endpoint_placeholder: '<api_endpoint_here>'
 base_revision: 20170710
-documentation_root_path: '/api/v2'
+documentation_root_path: ''
 
 language_tabs: # must be one of https://git.io/vQNgJ
   - shell

--- a/source/includes/20170710/getting_started/_authentication.md.erb
+++ b/source/includes/20170710/getting_started/_authentication.md.erb
@@ -8,7 +8,7 @@
 
 > Make sure to replace `<%= current_page.data.api_token_placeholder %>` with the API key.
 
-WaniKani uses your secret API token to authenticate requests to the API. You can obtain and manage your v2 token in [Settings / Account](https://www.wanikani.com/settings/account#public-api-key) on WaniKani. The token __has__ to be included with every request, and should be delivered in a HTTP header that looks like:
+WaniKani uses your secret API token to authenticate requests to the API. You can obtain and manage your v2 token in [Settings / API Tokens](https://www.wanikani.com/settings/personal_access_tokens) on WaniKani. The token __has__ to be included with every request, and should be delivered in a HTTP header that looks like:
 
 `Authorization: Bearer <%= current_page.data.api_token_placeholder %>`
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Changes proposed in this pull request:

* fix: link to https://www.wanikani.com/settings/personal_access_tokens, not the old token page
* fix: change `documentation_root_path` variable to fix 3 links: the title in the sidebar, and 2 references to `current_page.data.documentation_root_path`

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
