### PR TITLE
Fix a typo with the component_subject_ids description

### DIFF
--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -196,7 +196,7 @@ Attribute | Data Type | Description
 Attribute | Data Type | Description
 --------- | --------------- | -----------
 `amalgamation_subject_ids` | Array of integers | An array of numeric identifiers for the vocabulary that have the kanji as a component.
-`component_subject_ids` | Array of integers | An array of numeric identifiers for the radicals that make up this kanji. Note that these are the subjects that must be have passed assignments in order to unlock this subject's assignment.
+`component_subject_ids` | Array of integers | An array of numeric identifiers for the radicals that make up this kanji. Note that these are the subjects that must have passed assignments in order to unlock this subject's assignment.
 `readings` | Array of objects | Selected readings for the kanji. See table below for the object structure.
 `visually_similar_subject_ids`| Array of integers | An array of numeric identifiers for kanji which are visually similar to the kanji in question.
 


### PR DESCRIPTION
Changes proposed in this pull request:

* 👆. Thanks, xrmichah!

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
