### PR TITLE
Remove beta notices

### DIFF
--- a/source/includes/20170710/_introduction.md
+++ b/source/includes/20170710/_introduction.md
@@ -7,7 +7,3 @@ This version is built around a [REST](http://en.wikipedia.org/wiki/Representatio
 We've got information on general usage, like authentication and error codes, in [Getting Started](#getting-started). We make a few suggestions on how to optimize your usage of the API in [Best Practices](#best-practices) and clarify a few obscure topics under [Additional Information](#additional-information). Finally, details for all of the available resources and endpoints are under [Resources](#resources).
 
 Feel free to reach out [via email](mailto:hello@wanikani.com) or [through the community](https://community.wanikani.com/) if you have any questions, comments, or requests about the API.
-
-<aside class="warning">
-  <strong>Keep in mind this is an beta! There may be more endpoints to come and the structure of API results can be changed before release.</strong>
-</aside>

--- a/source/includes/20170710/getting_started/_revisions.md.erb
+++ b/source/includes/20170710/getting_started/_revisions.md.erb
@@ -1,9 +1,5 @@
 ## Revisions (aka Versioning)
 
-<aside class="warning">
-During alpha and beta we will not be versioning the API. Anticipate breaking changes.
-</aside>
-
 > To define the revision, use this code:
 
 <%= partial('examples/GET_shell') %>


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove beta notices since [API version 2 is moving out of beta](https://community.wanikani.com/t/api-version-2-moving-out-of-beta-sunsetting-api-version-1/42539).

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
