### PR TITLE
Add /spaced_repetition_systems

### DIFF
--- a/source/20170710/index.html.md
+++ b/source/20170710/index.html.md
@@ -43,6 +43,7 @@ includes:
   - 20170710/resources/resets
   - 20170710/resources/reviews
   - 20170710/resources/review_statistics
+  - 20170710/resources/spaced_repetition_systems
   - 20170710/resources/srs_stages
   - 20170710/resources/study_materials
   - 20170710/resources/subjects

--- a/source/includes/20170710/getting_started/_response_structure.md
+++ b/source/includes/20170710/getting_started/_response_structure.md
@@ -59,8 +59,9 @@ The following are singular resources:
 * `level_progression`
 * `radical`
 * `reset`
-* `review`
 * `review_statistic`
+* `review`
+* `spaced_repetition_system`
 * `study_material`
 * `user`
 * `vocabulary`

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -5,7 +5,7 @@ Assignments contain information about a user's progress on a particular subject,
 ## Assignment Data Structure
 
 <aside class="warning">
-  `assignment.srs_stage_name` is marked for deprecation. It will be dropped on August 15, 2020.
+  `assignment.srs_stage_name` is marked for deprecation. It will be dropped on August 17, 2020.
 </aside>
 
 > Example Structure

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -4,6 +4,10 @@ Assignments contain information about a user's progress on a particular subject,
 
 ## Assignment Data Structure
 
+<aside class="warning">
+  `assignment.srs_stage_name` is marked for deprecation. It will be dropped on August 15, 2020.
+</aside>
+
 > Example Structure
 
 ```json

--- a/source/includes/20170710/resources/_reviews.md.erb
+++ b/source/includes/20170710/resources/_reviews.md.erb
@@ -15,6 +15,7 @@ Reviews log all the correct and incorrect answers provided through the 'Reviews'
   "data": {
     "created_at": "2017-12-20T01:00:59.255427Z",
     "assignment_id": 32132,
+    "spaced_repetition_system_id": 1,
     "subject_id": 8,
     "starting_srs_stage": 4,
     "starting_srs_stage_name": "Apprentice IV",
@@ -34,11 +35,14 @@ Attribute | Date&nbsp;Type | Description
 `ending_srs_stage` | Integer | The SRS stage interval calculated from the number of correct and incorrect answers, with valid values ranging from `1` to `9`
 `incorrect_meaning_answers` | Integer | The number of times the user has answered the meaning incorrectly.
 `incorrect_reading_answers` | Integer | The number of times the user has answered the reading incorrectly.
+`spaced_repetition_system_id` | Integer | Unique identifier of the associated [spaced_repetition_system](#spaced_repetition_systems).
 `starting_srs_stage_name` | String | The [stage name](#srs-stage-intervals) associated with the `starting_srs_stage`.
 `starting_srs_stage` | Integer | The starting SRS stage interval, with valid values ranging from `1` to `8`
 `subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
 
 ### Notes
+
+#### Incorrect Answers
 
 A subject (radical, kanji, and vocabulary) may not require a meaning or reading. Therefore attributes `incorrect_meaning_answers` and `incorrect_reading_answers` will return a value of `0` for subjects which do not have the requirement.
 
@@ -47,6 +51,10 @@ Subject type | Answer types allowed
 kanji        | Meaning, Reading
 radical      | Meaning
 vocabulary   | Meaning, Reading
+
+#### Spaced Repetition System
+
+The associated spaced repetition system is the system used to do the SRS stage calculations at the time the review record was created. It does not necessarily mean it is the current `spaced_repetition_system` associated to `subject`. This is done to preserve history.
 
 ## Get All Reviews
 
@@ -78,6 +86,7 @@ vocabulary   | Meaning, Reading
       "data": {
         "created_at": "2017-12-20T01:00:59.255427Z",
         "assignment_id": 32132,
+        "spaced_repetition_system_id": 1,
         "subject_id": 8,
         "starting_srs_stage": 4,
         "starting_srs_stage_name": "Apprentice IV",
@@ -138,6 +147,7 @@ Assumptions:
   "data": {
     "created_at": "2017-12-20T01:00:59.255427Z",
     "assignment_id": 32132,
+    "spaced_repetition_system_id": 1,
     "subject_id": 8,
     "starting_srs_stage": 4,
     "starting_srs_stage_name": "Apprentice IV",
@@ -178,6 +188,7 @@ Name | Data Type | Description
   "data": {
     "created_at": "2018-05-13T03:34:54.000000Z",
     "assignment_id": 1422,
+    "spaced_repetition_system_id": 1,
     "subject_id": 997,
     "starting_srs_stage": 1,
     "starting_srs_stage_name": "Apprentice I",

--- a/source/includes/20170710/resources/_reviews.md.erb
+++ b/source/includes/20170710/resources/_reviews.md.erb
@@ -5,7 +5,7 @@ Reviews log all the correct and incorrect answers provided through the 'Reviews'
 ## Review Data Structure
 
 <aside class="warning">
-  `review.starting_srs_stage_name` and `review.ending_srs_stage_name` are marked for deprecation. They will be dropped on August 15, 2020.
+  `review.starting_srs_stage_name` and `review.ending_srs_stage_name` are marked for deprecation. They will be dropped on August 17, 2020.
 </aside>
 
 > Example Structure

--- a/source/includes/20170710/resources/_reviews.md.erb
+++ b/source/includes/20170710/resources/_reviews.md.erb
@@ -4,6 +4,10 @@ Reviews log all the correct and incorrect answers provided through the 'Reviews'
 
 ## Review Data Structure
 
+<aside class="warning">
+  `review.starting_srs_stage_name` and `review.ending_srs_stage_name` are marked for deprecation. They will be dropped on August 15, 2020.
+</aside>
+
 > Example Structure
 
 ```json

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -96,7 +96,7 @@ Attribute | Data Type | Description
 `interval_unit` | `null` or String | Unit of time. Can be the following: milliseconds, seconds, minutes, hours, days, and weeks.
 `position` | Integer | The position of the stage within the continuous order.
 
-The unlocking (position 0) and burning (maximum position) will always have `null` for `interval` and `interval_unit` since the stages do not influence `assignment.available_at`. Stages in between the unlocking and burning stages are the "reviewable" stages.
+The unlocking (position 0) and burning (maximum position) will always have `null` for `interval` and `interval_unit` since the stages do not influence `assignment.available_at`. Stages in between the unlocking and burning stages are the “reviewable” stages.
 
 ## Get All Spaced Repetition Systems
 

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -1,0 +1,358 @@
+# Spaced Repetition Systems
+
+Available spaced repetition systems used for calculating `srs_stage` changes to [Assignments](#assignments) and [Reviews](#reviews). Has relationship with [Subjects](#subjects)
+
+## Spaced Repetition System Data Structure
+
+> Example Structure
+
+```json
+{
+  "id": 1,
+  "object": "spaced_repetition_system",
+  "url": "<%= current_page.data.api_root_url %>/spaced_repetition_systems/1",
+  "data_updated_at": "2020-05-27T16:42:06.705681Z",
+  "data": {
+    "created_at": "2020-05-21T20:46:06.464460Z",
+    "name": "Default system for dictionary subjects",
+    "description": "The original spaced repetition system",
+    "unlocking_stage_position": 0,
+    "starting_stage_position": 1,
+    "passing_stage_position": 5,
+    "burning_stage_position": 9,
+    "stages": [
+      {
+        "interval": null,
+        "position": 0,
+        "interval_unit": null
+      },
+      {
+        "interval": 14400,
+        "position": 1,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 28800,
+        "position": 2,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 82800,
+        "position": 3,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 169200,
+        "position": 4,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 601200,
+        "position": 5,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 1206000,
+        "position": 6,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 2588400,
+        "position": 7,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 10364400,
+        "position": 8,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": null,
+        "position": 9,
+        "interval_unit": null
+      }
+    ]
+  }
+}
+```
+
+Attribute | Data&nbsp;Type | Description
+--------- | --------------- | -----------
+`burning_stage_position` | Integer | `position` of the burning stage.
+`description` | String | Details about the spaced repetition system.
+`name` | String | The name of the spaced repetition system
+`passing_stage_position` | Integer | `position` of the passing stage.
+`stages` | Array of objects | A collection of stages. See table below for the object structure.
+`starting_stage_position` | Integer | `position` of the starting stage.
+`unlocking_stage_position` | Integer | `position` of the unlocking stage.
+
+#### Stages Object Attributes
+
+Attribute | Data Type | Description
+--------- | --------------- | -----------
+`interval` | `null` or Integer |
+`interval_unit` | `null` or String |
+`position` | Integer |
+
+The unlocking (position 0) and burning (maximum position) will always have `null` for `interval` and `interval_unit` since the stages do not influence `assignment.available_at`. Stages in between the unlocking and burning stages are the "reviewable" stages.
+
+## Get All Spaced Repetition Systems
+
+> Example Request
+
+<%= partial('examples/GET_shell', locals: { api_endpoint: 'spaced_repetition_systems' }) %>
+
+<%= partial('examples/GET_javascript', locals: { api_endpoint: 'spaced_repetition_systems' }) %>
+
+> Example Response
+
+```json
+{
+  "object": "collection",
+  "url": "https://api.wanikani.com/v2/spaced_repetition_systems",
+  "pages": {
+    "per_page": 500,
+    "next_url": null,
+    "previous_url": null
+  },
+  "total_count": 2,
+  "data_updated_at": "2020-06-09T03:38:01.007395Z",
+  "data": [
+    {
+      "id": 1,
+      "object": "spaced_repetition_system",
+      "url": "https://api.wanikani.com/v2/spaced_repetition_systems/1",
+      "data_updated_at": "2020-06-09T03:36:51.134752Z",
+      "data": {
+        "created_at": "2020-05-21T20:46:06.464460Z",
+        "name": "Default system for dictionary subjects",
+        "description": "The original spaced repetition system",
+        "passing_stage_position": 5,
+        "stages": [
+          {
+            "interval": null,
+            "position": 0,
+            "interval_unit": null
+          },
+          {
+            "interval": 14400,
+            "position": 1,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 28800,
+            "position": 2,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 82800,
+            "position": 3,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 169200,
+            "position": 4,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 601200,
+            "position": 5,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 1206000,
+            "position": 6,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 2588400,
+            "position": 7,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 10364400,
+            "position": 8,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": null,
+            "position": 9,
+            "interval_unit": null
+          }
+        ]
+      }
+    },
+    {
+      "id": 2,
+      "object": "spaced_repetition_system",
+      "url": "https://api.wanikani.com/v2/spaced_repetition_systems/2",
+      "data_updated_at": "2020-06-09T03:38:01.007395Z",
+      "data": {
+        "created_at": "2020-05-21T20:48:06.470578Z",
+        "name": "Default accelerated system for dictionary subjects",
+        "description": "The original spaced repetition system, but accelerated",
+        "passing_stage_position": 5,
+        "stages": [
+          {
+            "interval": null,
+            "position": 0,
+            "interval_unit": null
+          },
+          {
+            "interval": 7200,
+            "position": 1,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 14400,
+            "position": 2,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 28800,
+            "position": 3,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 82800,
+            "position": 4,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 601200,
+            "position": 5,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 1206000,
+            "position": 6,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 2588400,
+            "position": 7,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": 10364400,
+            "position": 8,
+            "interval_unit": "seconds"
+          },
+          {
+            "interval": null,
+            "position": 9,
+            "interval_unit": null
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+Returns a collection of all spaced_repetition_systems, ordered by ascending `id`, 500 at a time.
+
+### HTTP Request
+
+`GET <%= current_page.data.api_root_url %>/spaced_repetition_systems`
+
+### Query Parameters
+
+The collection of spaced_repetition_systems will be filtered on the parameters provided.
+
+Name | Permitted values | Description
+---- | ---------------- | -----------
+`ids` | Array of integers | Only spaced_repetition_systems where `data.id` matches one of the array values are returned.
+`updated_after` | Date | Only spaced_repetition_systems updated after this time are returned.
+
+## Get a Specific Spaced Repetition System
+
+> Example Request
+
+<%= partial('examples/GET_shell', locals: { api_endpoint: 'spaced_repetition_systems/1' }) %>
+
+<%= partial('examples/GET_javascript', locals: { api_endpoint: 'spaced_repetition_systems/1' }) %>
+
+> Example Response
+
+```json
+{
+  "id": 1,
+  "object": "spaced_repetition_system",
+  "url": "<%= current_page.data.api_root_url %>/spaced_repetition_systems/1",
+  "data_updated_at": "2020-05-27T16:42:06.705681Z",
+  "data": {
+    "created_at": "2020-05-21T20:46:06.464460Z",
+    "name": "Default system for dictionary subjects",
+    "description": "The original spaced repetition system",
+    "unlocking_stage_position": 0,
+    "starting_stage_position": 1,
+    "passing_stage_position": 5,
+    "burning_stage_position": 9,
+    "stages": [
+      {
+        "interval": null,
+        "position": 0,
+        "interval_unit": null
+      },
+      {
+        "interval": 14400,
+        "position": 1,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 28800,
+        "position": 2,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 82800,
+        "position": 3,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 169200,
+        "position": 4,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 601200,
+        "position": 5,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 1206000,
+        "position": 6,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 2588400,
+        "position": 7,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": 10364400,
+        "position": 8,
+        "interval_unit": "seconds"
+      },
+      {
+        "interval": null,
+        "position": 9,
+        "interval_unit": null
+      }
+    ]
+  }
+}
+```
+
+Retrieves a specific spaced_repetition_system by its `id`.
+
+### HTTP Request
+
+`GET <%= current_page.data.api_root_url %>/spaced_repetition_systems/<id>`
+
+### Parameters
+
+Name | Data Type | Description
+---- | ---------------- | -----------
+`id` | Integer | Unique identifier of the spaced_repetition_system.

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -86,6 +86,8 @@ Attribute | Data&nbsp;Type | Description
 `starting_stage_position` | Integer | `position` of the starting stage.
 `unlocking_stage_position` | Integer | `position` of the unlocking stage.
 
+The past progressive `_position` fields align with the past tense timestamps of [assignment](#assignments).
+
 #### Stages Object Attributes
 
 Attribute | Data Type | Description

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -92,7 +92,7 @@ The `_position` fields align with the timestamps on [assignment](#assignments): 
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`interval` | `null` or Integer | The length of time added to time of review registration adjusted to the beginning of the hour.
+`interval` | `null` or Integer | The length of time added to the time of review registration, adjusted to the beginning of the hour.
 `interval_unit` | `null` or String | Unit of time. Can be the following: milliseconds, seconds, minutes, hours, days, and weeks.
 `position` | Integer | The position of the stage within the continuous order.
 

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -92,9 +92,9 @@ The past progressive `_position` fields align with the past tense timestamps of 
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`interval` | `null` or Integer |
-`interval_unit` | `null` or String |
-`position` | Integer |
+`interval` | `null` or Integer | The length of time added to time of review registration adjusted to the beginning of the hour.
+`interval_unit` | `null` or String | Unit of time. Can be the following: milliseconds, seconds, minutes, hours, days, and weeks.
+`position` | Integer | The position of the stage within the continuous order.
 
 The unlocking (position 0) and burning (maximum position) will always have `null` for `interval` and `interval_unit` since the stages do not influence `assignment.available_at`. Stages in between the unlocking and burning stages are the "reviewable" stages.
 

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -86,7 +86,7 @@ Attribute | Data&nbsp;Type | Description
 `starting_stage_position` | Integer | `position` of the starting stage.
 `unlocking_stage_position` | Integer | `position` of the unlocking stage.
 
-The past progressive `_position` fields align with the past tense timestamps of [assignment](#assignments).
+The `_position` fields align with the timestamps on [assignment](#assignments): `unlocking_stage_position` => `unlocked_at`, `passing_stage_position` => `passed_at`, etc.
 
 #### Stages Object Attributes
 

--- a/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
+++ b/source/includes/20170710/resources/_spaced_repetition_systems.md.erb
@@ -127,7 +127,10 @@ The unlocking (position 0) and burning (maximum position) will always have `null
         "created_at": "2020-05-21T20:46:06.464460Z",
         "name": "Default system for dictionary subjects",
         "description": "The original spaced repetition system",
+        "unlocking_stage_position": 0,
+        "starting_stage_position": 1,
         "passing_stage_position": 5,
+        "burning_stage_position": 9,
         "stages": [
           {
             "interval": null,
@@ -191,7 +194,10 @@ The unlocking (position 0) and burning (maximum position) will always have `null
         "created_at": "2020-05-21T20:48:06.470578Z",
         "name": "Default accelerated system for dictionary subjects",
         "description": "The original spaced repetition system, but accelerated",
+        "unlocking_stage_position": 0,
+        "starting_stage_position": 1,
         "passing_stage_position": 5,
+        "burning_stage_position": 9,
         "stages": [
           {
             "interval": null,

--- a/source/includes/20170710/resources/_srs_stages.md.erb
+++ b/source/includes/20170710/resources/_srs_stages.md.erb
@@ -1,5 +1,9 @@
 # SRS Stages
 
+<aside class="warning">
+  This endpoint will is marked for deprecation. It will be dropped on August 15, 2020. Please use the replacement endpoint instead, `[spaced_repetition_systems](#spaced_repetition_systems)`
+</aside>
+
 This report summarizes the space repetition intervals. These intervals are used to calculate the `assignment.available_at`.
 
 ## SRS Stages Data Structure

--- a/source/includes/20170710/resources/_srs_stages.md.erb
+++ b/source/includes/20170710/resources/_srs_stages.md.erb
@@ -1,7 +1,7 @@
 # SRS Stages
 
 <aside class="warning">
-  This endpoint will is marked for deprecation. It will be dropped on August 15, 2020. Please use the replacement endpoint instead, `[spaced_repetition_systems](#spaced_repetition_systems)`
+  This endpoint will is marked for deprecation. It will be dropped on August 17, 2020. Please use the replacement endpoint instead, `[spaced_repetition_systems](#spaced_repetition_systems)`
 </aside>
 
 This report summarizes the space repetition intervals. These intervals are used to calculate the `assignment.available_at`.

--- a/source/includes/20170710/resources/_srs_stages.md.erb
+++ b/source/includes/20170710/resources/_srs_stages.md.erb
@@ -1,7 +1,7 @@
 # SRS Stages
 
 <aside class="warning">
-  This endpoint will is marked for deprecation. It will be dropped on August 17, 2020. Please use the replacement endpoint instead, `[spaced_repetition_systems](#spaced_repetition_systems)`
+  This endpoint is marked for deprecation. It will be dropped on August 17, 2020. Please use the replacement endpoint instead, `[spaced_repetition_systems](#spaced_repetition_systems)`
 </aside>
 
 This report summarizes the space repetition intervals. These intervals are used to calculate the `assignment.available_at`.

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -20,6 +20,7 @@ Attribute | Data Type | Description
 `meaning_mnemonic` | String | The subject's meaning mnemonic.
 `meanings` | Array of objects | The subject meanings. See table below for the object structure.
 `slug` | String | The string that is used when generating the document URL for the subject. Radicals use their meaning, downcased. Kanji and vocabulary use their characters.
+`spaced_repetition_system_id` | Integer | Unique identifier of the associated [spaced_repetition_system](#spaced_repetition_systems).
 
 #### Meaning Object Attributes
 
@@ -101,6 +102,7 @@ The strings can include a WaniKani specific markup syntax. The following is a li
     ],
     "meaning_mnemonic": "This radical consists of a single, horizontal stroke. What's the biggest, single, horizontal stroke? That's the ground. Look at the <radical>ground</radical>, look at this radical, now look at the ground again. Kind of the same, right?",
     "slug": "ground",
+    "spaced_repetition_system_id": 2
   }
 }
 ```
@@ -189,6 +191,7 @@ Attribute | Data Type | Description
     "reading_hint": "Make sure you feel the ridiculously <reading>itchy</reading> sensation covering your body. It climbs from your hands, where you're holding the number <kanji>One</kanji> up, and then goes through your arms, crawls up your neck, goes down your body, and then covers everything. It becomes uncontrollable, and you're scratching everywhere, writhing on the ground. It's so itchy that it's the most painful thing you've ever experienced (you should imagine this vividly, so you remember the reading of this kanji).",
     "slug": "一",
     "visually_similar_subject_ids": [],
+    "spaced_repetition_system_id": 1
   }
 }
 ```
@@ -297,6 +300,7 @@ Attribute | Data Type | Description
     ],
     "reading_mnemonic": "When a vocab word is all alone and has no okurigana (hiragana attached to kanji) connected to it, it usually uses the kun'yomi reading. Numbers are an exception, however. When a number is all alone, with no kanji or okurigana, it is going to be the on'yomi reading, which you learned with the kanji.  Just remember this exception for alone numbers and you'll be able to read future number-related vocab to come.",
     "slug": "一",
+    "spaced_repetition_system_id": 1
   }
 }
 ```
@@ -419,7 +423,8 @@ Attribute | Data Type | Description
         "meaning_hint": "To remember the meaning of <kanji>One</kanji>, imagine yourself there at the scene of the crime. You grab <kanji>One</kanji> in your arms, trying to prop it up, trying to hear its last words. Instead, it just splatters some blood on your face. \"Who did this to you?\" you ask. The number One points weakly, and you see number Two running off into an alleyway. He's always been jealous of number One and knows he can be number one now that he's taken the real number one out.",
         "reading_mnemonic": "As you're sitting there next to <kanji>One</kanji>, holding him up, you start feeling a weird sensation all over your skin. From the wound comes a fine powder (obviously coming from the special bullet used to kill One) that causes the person it touches to get extremely <reading>itchy</reading> (いち)",
         "reading_hint": "Make sure you feel the ridiculously <reading>itchy</reading> sensation covering your body. It climbs from your hands, where you're holding the number <kanji>One</kanji> up, and then goes through your arms, crawls up your neck, goes down your body, and then covers everything. It becomes uncontrollable, and you're scratching everywhere, writhing on the ground. It's so itchy that it's the most painful thing you've ever experienced (you should imagine this vividly, so you remember the reading of this kanji).",
-        "lesson_position": 2
+        "lesson_position": 2,
+        "spaced_repetition_system_id": 1
       }
     }
   ]

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -73,7 +73,7 @@ The strings can include a WaniKani specific markup syntax. The following is a li
     ],
     "auxiliary_meanings": [
       {
-        "meaning": "grund",
+        "meaning": "ground",
         "type": "blacklist"
       }
     ],

--- a/source/includes/20170710/resources/_voice_actors.md.erb
+++ b/source/includes/20170710/resources/_voice_actors.md.erb
@@ -80,7 +80,7 @@ Name | Permitted values | Description
 `ids` | Array of integers | Only voice_actors where `data.id` matches one of the array values are returned.
 `updated_after` | Date | Only voice_actors updated after this time are returned.
 
-## Get a Specific Reset
+## Get a Specific Voice Actor
 
 > Example Request
 


### PR DESCRIPTION
Changes proposed in this pull request:

* Add /spaced_repetition_systems endpoint details
* Add `spaced_repetition_system_id` details on Subject and Reviews
* Add deprecation warnings for /srs_stages
* Add deprecation warnings for `assignment.srs_stage_name`, `review.starting_srs_stage_name`, and `review.ending_srs_stage_name`.
* Minor typos and corrections

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
