### PR TITLE
Remove assignment.passed

### DIFF
--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -5,7 +5,7 @@ Assignments contain information about a user's progress on a particular subject,
 ## Assignment Data Structure
 
 <aside class="warning">
-  `assignment.passed` is marked for deprecation. It will be dropped on August 15, 2020. The same information can be inferred by checking the presence of the `assignment.passed_at` timestamp.
+  `assignment.passed` is marked for deprecation. It will be dropped on August 17, 2020. The same information can be inferred by checking the presence of the `assignment.passed_at` timestamp.
 </aside>
 
 > Example Structure

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -4,6 +4,10 @@ Assignments contain information about a user's progress on a particular subject,
 
 ## Assignment Data Structure
 
+<aside class="warning">
+  `assignment.passed` is marked for deprecation. It will be dropped on August 15, 2020. The same information can be inferred by checking the presence of the `assignment.passed_at` timestamp.
+</aside>
+
 > Example Structure
 
 ```json


### PR DESCRIPTION
Changes proposed in this pull request:

* Add deprecation warning about the removal of `assignment.passed`

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
