### PR TITLE
fix(docs): Fix typos and broken links, add missing details

### DIFF
--- a/source/includes/20170710/_additional_information.md
+++ b/source/includes/20170710/_additional_information.md
@@ -2,7 +2,7 @@
 
 ## Spaced Repetition System
 
-Our [spaced repetition systems](#spaced-repetition-systems) determine how subjects progress from being unavailable to users (locked) through complete memorization (burned). The [knownledge guide](https://knowledge.wanikani.com/wanikani/srs-stages/) has some good general information about how we use SRS in WaniKani.
+Our [spaced repetition systems](#spaced-repetition-systems) determine how subjects progress from being unavailable to users (locked) through complete memorization (burned). The [knowledge guide](https://knowledge.wanikani.com/wanikani/srs-stages/) has some good general information about how we use SRS in WaniKani.
 
 A single spaced repetition system consists of `N` number of sequential stages. Each stage describes its position in the sequence as well as the time interval that’s used to determine when the subject will appear next in reviews.
 

--- a/source/includes/20170710/best_practices/_caching.md
+++ b/source/includes/20170710/best_practices/_caching.md
@@ -14,4 +14,4 @@ Do take note any of the above recommendations may become outdated, but we will t
 
 Caching is always tricky business. When do you expire it? How do you refresh it? Who's in charge of it?
 
-We've done a couple things to try and help with a couple of the problems around caching. The first is to support [conditional requests](#conditional-requests), which lets us quickly tell you that a record hasn't changed since you got it last. The second is to give you tools to [get only the updated or new records after any point in time](#leveraging-the-updated_after-filter), letting you easily refresh your local data caches and stores without having to parse _all_ the records.
+We've done a couple things to try and help with a couple of the problems around caching. The first is to support [conditional requests](#conditional-requests), which lets us quickly tell you that a record hasn't changed since you got it last. The second is to give you tools to [get only the updated or new records after any point in time](#leveraging-the-updated_after-code-filter), letting you easily refresh your local data caches and stores without having to parse _all_ the records.

--- a/source/includes/20170710/getting_started/_pagination.md
+++ b/source/includes/20170710/getting_started/_pagination.md
@@ -14,8 +14,8 @@ Collections have the following nested within a `pages` attribute:
 
 Attribute | Data Type | Description
 --------- | --- | -----------
-`next_url` | String | The URL of the next page of results. If there are no more results, the value is `null`.
-`previous_url` | String | The URL of the previous page of results. If there are no results at all or no previous page to go to, the value is `null`.
+`next_url` | `null` or String | The URL of the next page of results. If there are no more results, the value is `null`.
+`previous_url` | `null` or String | The URL of the previous page of results. If there are no results at all or no previous page to go to, the value is `null`.
 `per_page` | Integer | Maximum number of resources delivered for this collection.
 
 <aside class="notice">

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -35,7 +35,7 @@ Attribute | Data Type | Description
 `hidden` | Boolean | Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
 `passed_at` | `null` or Date | Timestamp when the user reaches SRS stage `5` for the first time.
 `resurrected_at` | `null` or Date | Timestamp when the subject is resurrected and placed back in the user's review queue.
-`srs_stage` | Integer | The current [SRS stage interval](#srs-stage-intervals), from `0` to `9`.
+`srs_stage` | Integer | The current [SRS stage interval](#spaced-repetition-systems). The interval range is determined by the related [subject's](#subjects) [spaced repetition system](#spaced-repetition-systems]).
 `started_at` | `null` or Date | Timestamp when the user completes the lesson for the related subject.
 `subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
 `subject_type` | String | The type of the associated [subject](#subjects), one of: `kanji`, `radical`, or `vocabulary`.

--- a/source/includes/20170710/resources/_level_progressions.md.erb
+++ b/source/includes/20170710/resources/_level_progressions.md.erb
@@ -15,7 +15,7 @@ A level progression is created when a user has met the prerequisites for levelin
 {
   "id": 49392,
   "object": "level_progression",
-  "url": "https://www.wanikani.com/api/v2/level_progressions/49392",
+  "url": "https://api.wanikani.com/v2/level_progressions/49392",
   "data_updated_at": "2017-03-30T11:31:20.438432Z",
   "data": {
     "created_at": "2017-03-30T08:21:51.439918Z",
@@ -52,7 +52,7 @@ Attribute | Possible Values | Description
 ```json
 {
   "object": "collection",
-  "url": "https://www.wanikani.com/api/v2/level_progressions",
+  "url": "https://api.wanikani.com/v2/level_progressions",
   "pages": {
     "per_page": 500,
     "next_url": null,
@@ -64,7 +64,7 @@ Attribute | Possible Values | Description
     {
       "id": 49392,
       "object": "level_progression",
-      "url": "https://www.wanikani.com/api/v2/level_progressions/49392",
+      "url": "https://api.wanikani.com/v2/level_progressions/49392",
       "data_updated_at": "2017-03-30T11:31:20.438432Z",
       "data": {
         "created_at": "2017-03-30T08:21:51.439918Z",

--- a/source/includes/20170710/resources/_reviews.md.erb
+++ b/source/includes/20170710/resources/_reviews.md.erb
@@ -32,7 +32,7 @@ Attribute | Date&nbsp;Type | Description
 `ending_srs_stage` | Integer | The SRS stage interval calculated from the number of correct and incorrect answers, with valid values ranging from `1` to `9`
 `incorrect_meaning_answers` | Integer | The number of times the user has answered the meaning incorrectly.
 `incorrect_reading_answers` | Integer | The number of times the user has answered the reading incorrectly.
-`spaced_repetition_system_id` | Integer | Unique identifier of the associated [spaced_repetition_system](#spaced_repetition_systems).
+`spaced_repetition_system_id` | Integer | Unique identifier of the associated [spaced_repetition_system](#spaced-repetition-systems).
 `starting_srs_stage` | Integer | The starting SRS stage interval, with valid values ranging from `1` to `8`
 `subject_id` | Integer | Unique identifier of the associated [subject](#subjects).
 

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -14,7 +14,7 @@ Attribute | Data Type | Description
 `characters` | String | The UTF-8 characters for the subject, including kanji and hiragana.
 `created_at` | Date | Timestamp when the subject was created.
 `document_url` | String | A URL pointing to the page on wanikani.com that provides detailed information about this subject.
-`hidden_at` | Date | Timestamp when the subject was hidden, indicating associated assignments will no longer appear in lessons or reviews and that the subject page is no longer visible on wanikani.com.
+`hidden_at` | `null` or Date | Timestamp when the subject was hidden, indicating associated assignments will no longer appear in lessons or reviews and that the subject page is no longer visible on wanikani.com.
 `lesson_position` | Integer | The position that the subject appears in lessons. Note that the value is scoped to the level of the subject, so there are duplicate values across levels.
 `level` | Integer | The level of the subject, from `1` to `60`.
 `meaning_mnemonic` | String | The subject's meaning mnemonic.
@@ -200,8 +200,8 @@ Attribute | Data Type | Description
 --------- | --------------- | -----------
 `amalgamation_subject_ids` | Array of integers | An array of numeric identifiers for the vocabulary that have the kanji as a component.
 `component_subject_ids` | Array of integers | An array of numeric identifiers for the radicals that make up this kanji. Note that these are the subjects that must have passed assignments in order to unlock this subject's assignment.
-`meaning_hint` | String | Meaning hint for the kanji.
-`reading_hint` | String | Reading hint for the kanji.
+`meaning_hint` | `null` or String | Meaning hint for the kanji.
+`reading_hint` | `null` or String | Reading hint for the kanji.
 `reading_mnemonic` | String | The kanji's reading mnemonic.
 `readings` | Array of objects | Selected readings for the kanji. See table below for the object structure.
 `visually_similar_subject_ids`| Array of integers | An array of numeric identifiers for kanji which are visually similar to the kanji in question.

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -129,7 +129,7 @@ The metadata object differs depending on the content_type
 
 Attribute | Data Type | Description
 --------- | --------------- | -----------
-`inline_styles` | Boolean | The SVG asset contains built in CSS styling
+`inline_styles` | Boolean | The SVG asset contains built-in CSS styling
 
 ##### When content_type is `image/png`
 

--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -121,6 +121,24 @@ Attribute | Data Type | Description
 `content_type` | String | The content type of the image. Currently the API delivers `image/png` and `image/svg+xml`.
 `metadata` | Object | Details about the image. Each `content_type` returns a uniquely structured object.
 
+##### Character Image Metadata Object Attributes
+
+The metadata object differs depending on the content_type
+
+##### When content_type is `image/svg+xml`
+
+Attribute | Data Type | Description
+--------- | --------------- | -----------
+`inline_styles` | Boolean | The SVG asset contains built in CSS styling
+
+##### When content_type is `image/png`
+
+Attribute | Data Type | Description
+--------- | --------------- | -----------
+`color` | String | Color of the asset in hexadecimal
+`dimensions` | String | Dimension of the asset in pixels
+`style_name` | String | A name descriptor
+
 ---
 
 ### Kanji Attributes


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix typos and broken links, add missing details
* Add metadata details for radical.character_images metadata

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
