### PR TITLE
fix(docs): add missing detail about assignments possibly being available for subjects above user's level

### DIFF
--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -87,6 +87,10 @@ Attribute | Data Type | Description
 
 Returns a collection of all assignments, ordered by ascending `created_at`, 500 at a time.
 
+<aside class="warning">
+It is possible for a user to have started an assignment for a subject that was later moved to a level above their current level. To exclude those assignments, filter by `levels` from 1 to the users current level
+</aside>
+
 ### HTTP Request
 
 `GET <%= current_page.data.api_root_url %>/assignments`

--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -88,7 +88,7 @@ Attribute | Data Type | Description
 Returns a collection of all assignments, ordered by ascending `created_at`, 500 at a time.
 
 <aside class="warning">
-It is possible for a user to have started an assignment for a subject that was later moved to a level above their current level. To exclude those assignments, filter by `levels` from 1 to the users current level
+It is possible for a user to have started an assignment for a subject that was later moved to a level above their current level. To exclude those assignments, filter by <code>levels</code> from 1 to the users current level
 </aside>
 
 ### HTTP Request


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Changes proposed in this pull request:

* Add edge case documentation for Get All Assigments endpoint, re: assignments for subjects that have moved above a user's current level

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
