### PR TITLE
Add details about `RateLimit-*` headers

### DIFF
--- a/source/includes/20170710/getting_started/_rate_limit.md
+++ b/source/includes/20170710/getting_started/_rate_limit.md
@@ -7,3 +7,13 @@ Throttle | Value
 Requests per minute | 60
 
 An HTTP status code of `429` (Forbidden) and a body with the message `Rate Limit Exceeded` is returned if the limits are exceeded (shocking, we know).
+
+In the response headers, the following rate limit information is provided:
+
+Header | Description
+------ | -----------
+RateLimit-Limit | The rate limit for the current period.
+RateLimit-Remaining | The remaining rate available for the current period.
+RateLimit-Reset | The timestamp of when the rate limit will reset. The value is epoch time in seconds.
+
+It is recommended to make use of the header rate limit details to programatically handle HTTP status code `429` responses in an optimal way.


### PR DESCRIPTION
Changes proposed in this pull request:

* Add details about available `RateLimit-*` headers

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
