### PR TITLE
Fix: Missing commas in documentation

### DIFF
--- a/source/includes/20170710/resources/_subjects.md.erb
+++ b/source/includes/20170710/resources/_subjects.md.erb
@@ -91,7 +91,7 @@ The strings can include a WaniKani specific markup syntax. The following is a li
     "created_at": "2012-02-27T18:08:16.000000Z",
     "document_url": "https://www.wanikani.com/radicals/ground",
     "hidden_at": null,
-    "lesson_position": 1
+    "lesson_position": 1,
     "level": 1,
     "meanings": [
       {
@@ -174,7 +174,7 @@ Attribute | Data Type | Description
     "created_at": "2012-02-27T19:55:19.000000Z",
     "document_url": "https://www.wanikani.com/kanji/%E4%B8%80",
     "hidden_at": null,
-    "lesson_position": 2
+    "lesson_position": 2,
     "level": 1,
     "meanings": [
       {


### PR DESCRIPTION
Closes https://github.com/tofugu/engineering-issues/issues/345

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
