### PR TITLE
remove link to list of revisions

### DIFF
--- a/source/includes/20170710/getting_started/_revisions.md.erb
+++ b/source/includes/20170710/getting_started/_revisions.md.erb
@@ -13,8 +13,6 @@ Any time we make ‘breaking changes’ to the API, we release a new, timestampe
 
 Revisions are designated by timestamps in the format `YYYYMMDD`. We expect the revision to be included in all API requests to the server in a header that looks like the following: `Wanikani-Revision: <%= current_page.data.api_revision %>`.
 
-See the [list of revisions and changelogs](<%= current_page.data.documentation_root_path %>) for more details.
-
 <aside class="notice">
 If you don't specify a revision, the API will default to the first revision: <a href="<%= current_page.data.documentation_root_path %>/<%= current_page.data.base_revision %>" title="View API revision 20170710 documentation"><%= current_page.data.base_revision %></a>.
 </aside>


### PR DESCRIPTION
This PR removes the link to the list of revisions.  We don't actually have a list of revisions so it is confusing to click the link and be taken to the top of the page where you won't find "more details".  Best course of action was to remove it.

Related to this backlog task: https://www.notion.so/tofugu/Fix-Dead-Link-in-API-Docs-cdb9445fd4ee42a5b7ee432296d6ddd2?pvs=4
---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
