### PR TITLE
fix assignments example

### DIFF
--- a/source/includes/20170710/resources/_assignments.md.erb
+++ b/source/includes/20170710/resources/_assignments.md.erb
@@ -124,7 +124,7 @@ Name | Data Type | Description
 
 If the date time now is November 11, 2017 8:42:00 AM UTC:
 
-`<%= current_page.data.api_root_url %>/assignments?available_after=2017-11-11T10:42:00Z`
+`<%= current_page.data.api_root_url %>/assignments?available_before=2017-11-11T10:42:00Z`
 
 #### Level 8 and 42 Kanji Assignments Which Have Been Burned
 


### PR DESCRIPTION
A user pointed out the following via support on Front.

> I think there's a mistake in the API example [Assignments Available for Review in Two Hours](https://docs.api.wanikani.com/20170710/#assignments-available-for-review-in-two-hours).
The query parameter used in that example "available_after=<2 hours from now>" would return the set of assignments that will not be available in two hours but will become available at some time after that. 
To return all assignments that will be available by two hours from now (including assignments that are already available now), the query parameter should be "available_before=<2 hours from now>".
If the intent is to exclude assignments that are available now and return only those assignments that will become available in the next two hours, the query parameters should be "available_after=<current time>&available_before=<2 hours from now>".
Apologies if I've misunderstood something.

I am inclined to agree so I have updated the docs.

---

The credentials to view the Netlify deploy is the following:

* **username**: crabigator
* **password**: noblowfishallowed
